### PR TITLE
Enable autoprefixer

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,9 +114,17 @@ exports.inlineSassLoader = {
     ]
 };
 
+const stubLoader = {
+    test: /\.(ttf|eot|svg|woff|woff2|jpe?g|png|gif|svg)$/i,
+    loader: require.resolve('./stub-loader.js')
+};
+
 // adds theme configuration to webpack config
-const webpackThemeConfig = (webpackConfig, settings) => {
-    const extract = settings && settings.extract;
+const webpackThemeConfig = (_settings, _webpackConfig) => {
+    const options = _webpackConfig ? _settings : {};
+    const webpackConfig = _webpackConfig ? _webpackConfig : _settings;
+
+    const extract = options && options.extract;
     const sassLoader = extract ? exports.CDNSassLoader : exports.inlineSassLoader;
     const plugins = extract ? [ exports.extractCssPlugin() ] : [];
 
@@ -127,7 +135,7 @@ const webpackThemeConfig = (webpackConfig, settings) => {
             loaders: _.flatten([
                 webpackConfig.module && webpackConfig.module.loaders,
                 sassLoader,
-                resourceLoaders
+                options.stubResources ? stubLoader : resourceLoaders
             ])
         },
         postcss: () => ([

--- a/index.js
+++ b/index.js
@@ -26,11 +26,15 @@ const cssLoaderPath = require.resolve('css-loader');
 const urlLoaderPath = require.resolve('url-loader');
 const styleLoaderPath = require.resolve('style-loader');
 const sassLoaderPath = require.resolve('sass-loader');
+const postCssLoaderPath = require.resolve('postcss-loader');
+const autoprefixer = require('autoprefixer');
 
 const cssModuleIdentName = 'k-[local]';
 
 const SRC = "src";
 const SRC_EXT_GLOB = ".{jsx,ts}";
+
+const cssLoaderQuery = `modules&localIdentName=${cssModuleIdentName}&importLoaders=1`;
 
 exports.webpack = webpack;
 
@@ -39,7 +43,8 @@ exports.webpackStream = webpackStream;
 exports.CDNSassLoader = {
     test: /\.scss$/,
     loader: ExtractTextPlugin.extract(styleLoaderPath, [
-        `${cssLoaderPath}?modules&sourceMap&localIdentName=${cssModuleIdentName}`,
+        `${cssLoaderPath}?sourceMap&${cssLoaderQuery}`,
+        postCssLoaderPath,
         sassLoaderPath
     ])
 };
@@ -79,7 +84,8 @@ const inlineSassLoader = {
     test: /\.scss$/,
     loaders: [
         styleLoaderPath,
-        `${cssLoaderPath}?modules&localIdentName=${cssModuleIdentName}`,
+        `${cssLoaderPath}?${cssLoaderQuery}`,
+        postCssLoaderPath,
         `${sassLoaderPath}?sourceMap`
     ]
 };
@@ -143,8 +149,15 @@ exports.webpackDevConfig = (config) => ({
     ],
 
     module: {
-        loaders: config.loaders.concat([ inlineSassLoader ]).concat(resourceLoaders)
-    }
+        loaders: _.flatten([
+            config.loaders,
+            inlineSassLoader,
+            resourceLoaders
+        ])
+    },
+    postcss: () => ([
+        autoprefixer
+    ])
 });
 
 exports.startKarma = (done, confPath, singleRun) => (

--- a/index.js
+++ b/index.js
@@ -44,9 +44,24 @@ exports.CDNSassLoader = {
     ])
 };
 
+const hashedName = "[name].[ext]?[hash]";
 const resourceLoaders = [
-    { test: /\.(jpe?g|png|gif|svg)$/i, loader: `${urlLoaderPath}?name=[name].[ext]?[hash]&limit=10000` },
-    { test: /\.(woff|woff2)$/, loader: `${urlLoaderPath}?name=[name].[ext]?[hash]&mimetype=application/font-woff` }
+    {
+        test: /\.(jpe?g|png|gif|svg)$/i,
+        loader: urlLoaderPath,
+        query: {
+            name: hashedName,
+            limit: 10000
+        }
+    },
+    {
+        test: /\.(woff|woff2)$/,
+        loader: urlLoaderPath,
+        query: {
+            name: hashedName,
+            mimetype: "application/font-woff"
+        }
+    }
 ];
 
 exports.resourceLoaders = resourceLoaders;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "@telerik/eslint-config": "1.1.0",
+    "autoprefixer": "^6.3.6",
     "babel-eslint": "^4.1.6",
     "browser-sync": "2.10.0",
     "browser-sync-webpack-plugin": "^1.0.1",
@@ -51,6 +52,7 @@
     "markdown-serve": "underlog/markdown-serve#master",
     "node-sass": "^3.4.2",
     "phantomjs-prebuilt": ">=1.9",
+    "postcss-loader": "^0.8.2",
     "sass-loader": "^3.1.2",
     "serve-index": "^1.7.3",
     "socket.io": "=1.4.5",

--- a/stub-loader.js
+++ b/stub-loader.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+    return '{}';
+};


### PR DESCRIPTION
Adds a PostCSS loader and the autoprefixer plug-in. I extracted the configuration of the theme loaders to a method, so that it can be used in `react-tasks` and `angular-tasks` (probably in customer webpack configurations, too). An added benefit is that changing theme loaders does not require changes in downstream packages.

This will allow us to remove the exports of `resourceLoaders`, `inlineSassLoader`, `CDNSassLoader` and `extractCssPlugin`, but I've kept them for backwards compatibility at this time.