### PR TITLE
fix: gulp start with linked package

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,7 +289,7 @@ exports.addTasks = (gulp, libraryName, srcGlob, webpackConfig, dtsGlob) => { //e
             const packageInfo = require(path.join(process.cwd(), 'package.json'));
 
             const config = _.assign({}, webpackConfig.dev);
-            config.resolve = Object.assign({}, config.resolve, { alias: { [packageInfo.name]: process.cwd() + '/src/main' } });
+            config.resolve = Object.assign({}, config.resolve, { alias: { [packageInfo.name]: process.cwd() + '/src/main' }, fallback: path.join(process.cwd(), 'node_modules') });
 
             const server = new WebpackDevServer(webpack(config), {
                 contentBase: './',

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ const addHMR = (path) =>
 
 exports.resolveConfig = ( extensions, nodeModulesPath ) => ({
     extensions: [ '', '.js' ].concat(extensions, [ '.scss' ]),
-    fallback: [ nodeModulesPath, path.join(__dirname, 'node_modules') ]
+    fallback: [ nodeModulesPath, path.join(__dirname, 'node_modules'), path.join(process.cwd(), 'node_modules') ]
 });
 
 exports.inlineSassLoader = {


### PR DESCRIPTION
Related to: http://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-don-t-find-their-dependencies

Not sure if this is the best place to add the fallback but seems to work on my side.