### PR TITLE
fix: more karma options

### DIFF
--- a/index.js
+++ b/index.js
@@ -475,7 +475,9 @@ exports.karmaConfig = function(config, webpackConfig, bundleFile) {
         autoWatch: true,
 
         browsers: browsers,
-
+        browserDisconnectTolerance: 5,
+        browserNoActivityTimeout: 30000,
+        retryLimit: 5,
         customLaunchers: {
             TravisCI: {
                 base: "Chrome",


### PR DESCRIPTION
Timeout and retries are added to karma config and disconnect tolerance as well. Else the build repeatedly fails on our build machine, probably default timeout is not enough. Other options are adding stability in case of unexpected browser disconnect. 