### PR TITLE
feat: explicitly add Http common package

### DIFF
--- a/docs-public/example-runner.js
+++ b/docs-public/example-runner.js
@@ -124,7 +124,7 @@ window.ExampleRunner = (function() {
                 'typescript': 'https://unpkg.com/typescript@2.3.4/lib/typescript.js',
 
                 // explicitly add subpackages
-                '@angular/http/testing': 'https://unpkg.com/@angular/http' + ngVer + '/bundles/http-testing.umd.js',
+                '@angular/common/http': 'https://unpkg.com/@angular/common' + ngVer + '/bundles/common-http.umd.js',
                 '@angular/platform-browser/animations': 'https://unpkg.com/@angular/platform-browser' + ngVer + '/bundles/platform-browser-animations.umd.js',
                 '@angular/animations/browser': 'https://unpkg.com/@angular/animations' + ngVer + '/bundles/animations-browser.umd.js'
             };

--- a/docs-public/example-runner.js
+++ b/docs-public/example-runner.js
@@ -158,7 +158,6 @@ window.ExampleRunner = (function() {
                 'compiler',
                 'forms',
                 'core',
-                'http',
                 'platform-browser',
                 'platform-browser-dynamic',
                 'upgrade'

--- a/docs-public/snippets.js
+++ b/docs-public/snippets.js
@@ -298,7 +298,6 @@ var directivesByModule = {
     angular: [
         { module: '@angular/core', match: '@(Component)', import: "Component" },
         { module: '@angular/forms', match: 'ngModel', import: "FormsModule" },
-        { module: '@angular/http', match: 'Http', import: "HttpModule" },
         { module: '@angular/platform-browser', match: '.', import: "BrowserModule" },
         { module: '@angular/platform-browser/animations', match: '.', import: "BrowserAnimationsModule" }
     ].concat(moduleDirectives),


### PR DESCRIPTION
Not ready for merging, opened for discussion only.

I suggest completely removing the old HttpModule and migrating to the new HttpCommonModule for all demos. Currently it seems to be used in Grid, Charts, Layout, Upload. Migration in packages different than the Upload should be trivial.

cc @gyoshev @tsvetomir 