### PR TITLE
fix: version of node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "merge2": "^1.0.2",
     "mkdirp": "^0.5.0",
     "module-deps": "4.0.7",
-    "node-sass": "^4.7.1",
+    "node-sass": "4.6.1",
     "postcss-calc": "^6.0.0",
     "postcss-loader": "^0.8.2",
     "resolve-url-loader": "^1.5.0",


### PR DESCRIPTION
We need this in order to have it on our build machines